### PR TITLE
Improve pubsub interface

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,3 +1,40 @@
 # PyEnsign
 
 PyEnsign is the official Python SDK for [Ensign](https://rotational.io/ensign), a distributed event store and stream-processing platform. This library allows you to interact with the Ensign API directly from Python in order to create [publishers](https://ensign.rotational.dev/eventing/glossary/#publisher) and [subscribers](https://ensign.rotational.dev/eventing/glossary/#subscriber).
+
+## Installation
+
+```
+pip install pyensign
+```
+
+## Usage
+
+Create a client from a client ID and client secret. If not provided, these will be obtained from the `ENSIGN_CLIENT_ID` and `ENSIGN_CLIENT_SECRET` variables.
+
+```python
+from pyensign.ensign import Ensign
+
+client = Ensign(client_id=<your client ID>, client_secret=<your client secret>)
+```
+
+The `Event` class can be used to create events from the raw data and mimetype.
+
+```python
+from pyensign.events import Event
+
+event = Event(b'{"temp": 72, "units": "fahrenheit"}', "APPLICATION_JSON")
+```
+
+Publish events to a topic. This function accepts anything that is iterable. Errors are concatenated into a list and returned after all the events have been published.
+
+```python
+errors = await client.publish("weather", event)
+```
+
+Subcribe to a topic or list of topics.
+
+```python
+async for event in client.subscribe("weather"):
+    print("Received event: {}".format(event))
+```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,70 @@ The project dependencies can be installed with pip.
 $ pip install -r requirements.txt
 ```
 
+If you wish to run the tests, you must install the test dependencies instead.
+
+```
+$ pip install -r tests/requirements.txt
+```
+
+## Configuration
+
+The `Ensign` client provides access to the unified API for managing topics and publishing/subscribing to topics. Creating a client requires a client ID and client secret (your API key).
+
+```python
+from pyensign.ensign import Ensign
+
+client = Ensign(client_id=<your client ID>, client_secret=<your client secret>)
+```
+
+If not provided the client ID and client secret will be obtained from the `ENSIGN_CLIENT_ID` and `ENSIGN_CLIENT_SECRET` environment variables.
+
+## Publishing
+
+Use `Ensign.publish()` to publish events to a topic. All events must contain some data and a mimetype. If the topic doesn't exist in your project, it will be automatically created.
+
+```python
+from pyensign.events import Event
+
+# Publishing a single event
+event = Event(b'{"temp": 72, "units": "fahrenheit"}', "APPLICATION_JSON")
+await client.publish("weather", event)
+
+# Publishing mulitple events
+events = [
+    Event(b'{"temp": 72, "units": "fahrenheit"}', "APPLICATION_JSON")
+    Event(b'{"temp": 76, "units": "fahrenheit"}', "APPLICATION_JSON")
+]
+await client.publish("weather", events)
+```
+
+## Subscribing
+
+Use `Ensign.subscribe()` to subscribe to one or more topics.
+
+```python
+async for event in client.subscribe("weather", "forecast")
+    print("Received event: {}".format(event))
+```
+
+## Design patterns
+
+Most event-driven applications require some form of concurrency. Therefore, the `Ensign` class is designed to be used asynchronously by defining coroutines. You can use Python's builtin `asyncio` package to schedule and run coroutines from the main thread.
+
+```python
+import asyncio
+from pyensign.ensign import Ensign
+
+async def subscriber(topic):
+    ...
+
+    async for event in client.subscribe(topic):
+        # Do something with the event
+
+def main():
+    asyncio.run(subscribe(topic))
+```
+
 ## Building the protocol buffers
 
 This repo relies on [protocol buffers](https://protobuf.dev/) for code generation. If you need to rebuild the protocol buffers, clone the ensign repo to the parent directory.

--- a/pyensign/ensign.py
+++ b/pyensign/ensign.py
@@ -96,7 +96,6 @@ class Ensign:
 
         errors = []
         async for publication in self.client.publish(next()):
-            print(publication)
             rep_type = publication.WhichOneof("embed")
             if rep_type == "ack":
                 continue
@@ -106,7 +105,6 @@ class Ensign:
                 break
             else:
                 raise EnsignResponseType(f"unexpected response type: {rep_type}")
-        print("stream closed")
         return errors
 
     async def subscribe(self, *topic_ids, consumer_id="", consumer_group=None):

--- a/pyensign/events.py
+++ b/pyensign/events.py
@@ -1,0 +1,65 @@
+from pyensign.api.v1beta1 import event_pb2
+from pyensign.mimetype.v1beta1 import mimetype_pb2
+
+mimetypes = mimetype_pb2.DESCRIPTOR.enum_types_by_name["MIME"].values_by_name
+mimetype_names = mimetypes.keys()
+
+
+class Event:
+    """
+    Event is an abstraction of an Ensign protocol buffer Event to make it easier to
+    create and parse events.
+    """
+
+    def __init__(self, data=None, mimetype=None):
+        """
+        Create a new Event from a mimetype and data.
+
+        Parameters
+        ----------
+        data : bytes
+            The data to use for the event.
+        mimetype: str or int
+            The mimetype of the data (e.g. "APPLICATION_JSON").
+        """
+
+        if not data:
+            raise ValueError("no data provided")
+
+        if not mimetype:
+            raise ValueError("no mimetype provided")
+
+        # TODO: Support traditionally formatted mimetypes (e.g. application/json)
+        if isinstance(mimetype, str):
+            if mimetype not in mimetypes:
+                raise ValueError(
+                    "invalid mimetype, specify one of: {}".format(mimetype_names)
+                )
+            self.mimetype = mimetypes[mimetype].number
+        else:
+            self.mimetype = mimetype
+
+        self.data = data
+        self.type = event_pb2.Type(name="Generic", version=1)
+
+    def proto(self, topic_id):
+        """
+        Return the protocol buffer representation of the event.
+
+        Parameters
+        ----------
+        topic_id : str
+            The topic ID to use when publishing the event.
+
+        Returns
+        -------
+        api.v1beta1.event_pb2.Event
+            The protocol buffer representation of the event with the topic ID set.
+        """
+
+        if not topic_id:
+            raise ValueError("no topic_id provided")
+
+        return event_pb2.Event(
+            topic_id=topic_id, data=self.data, mimetype=self.mimetype, type=self.type
+        )

--- a/tests/pyensign/test_ensign.py
+++ b/tests/pyensign/test_ensign.py
@@ -1,13 +1,18 @@
 import os
-import json
+import mmh3
+import base64
 import pytest
 import asyncio
 from ulid import ULID
 from unittest import mock
+from asyncmock import patch
 
 from pyensign.ensign import Ensign
+from pyensign.events import Event
+from pyensign.api.v1beta1 import ensign_pb2
 from pyensign.api.v1beta1 import event_pb2
 from pyensign.api.v1beta1 import topic_pb2
+from pyensign.exceptions import EnsignTopicCreateError
 from pyensign.mimetype.v1beta1.mimetype_pb2 import MIME
 
 
@@ -24,6 +29,19 @@ def authserver():
 @pytest.fixture
 def ensignserver():
     return os.environ.get("ENSIGN_SERVER")
+
+
+@pytest.fixture
+def ensign():
+    return Ensign(client_id="id", client_secret="secret", endpoint="localhost:1234")
+
+
+def async_iter(items):
+    async def next():
+        for item in items:
+            yield item
+
+    return next()
 
 
 class TestEnsign:
@@ -66,6 +84,130 @@ class TestEnsign:
             Ensign(client_id=client_id, client_secret=client_secret)
 
     @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.list_topics")
+    @patch("pyensign.connection.Client.publish")
+    async def test_publish_exists(self, mock_publish, mock_list, ensign):
+        name = "otters"
+        pubs = [
+            ensign_pb2.Publication(ack=ensign_pb2.Ack()),
+            ensign_pb2.Publication(nack=ensign_pb2.Nack()),
+            ensign_pb2.Publication(close_stream=ensign_pb2.CloseStream()),
+        ]
+        mock_publish.return_value = async_iter(pubs)
+        mock_list.return_value = ([topic_pb2.Topic(name=name, id=ULID().bytes)], "")
+
+        # Publish two events, one of them errors
+        events = [
+            Event(b'{"foo": "bar"}', MIME.APPLICATION_JSON),
+            Event(b'{"bar": "bz"}', MIME.APPLICATION_JSON),
+        ]
+
+        errors = await ensign.publish(name, events)
+        assert len(errors) == 1
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.list_topics")
+    @patch("pyensign.connection.Client.create_topic")
+    @patch("pyensign.connection.Client.publish")
+    async def test_publish_not_exists(
+        self, mock_publish, mock_create, mock_list, ensign
+    ):
+        name = "otters"
+        id = ULID().bytes
+        pubs = [
+            ensign_pb2.Publication(ack=ensign_pb2.Ack()),
+            ensign_pb2.Publication(nack=ensign_pb2.Nack()),
+            ensign_pb2.Publication(close_stream=ensign_pb2.CloseStream()),
+        ]
+        mock_publish.return_value = async_iter(pubs)
+        mock_create.return_value = topic_pb2.Topic(id=id, name=name)
+        mock_list.return_value = ([], "")
+
+        # Publish two events, one of them errors
+        events = [
+            Event(b'{"foo": "bar"}', MIME.APPLICATION_JSON),
+            Event(b'{"bar": "bz"}', MIME.APPLICATION_JSON),
+        ]
+        errors = await ensign.publish(name, events)
+        assert len(errors) == 1
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.status")
+    async def test_status(self, mock_status, ensign):
+        mock_status.return_value = ("AVAILABLE", "1.0.0", "10 minutes", "", "")
+        status = await ensign.status()
+        assert status == "status: AVAILABLE\nversion: 1.0.0\nuptime: 10 minutes"
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.subscribe")
+    async def test_subscribe(self, mock_subscribe, ensign):
+        events = [
+            event_pb2.Event(
+                id=str(ULID()),
+                data=b'{"foo": "bar"}',
+                mimetype=MIME.APPLICATION_JSON,
+            ),
+            event_pb2.Event(
+                id=str(ULID()),
+                data=b'{"bar": "bz"}',
+                mimetype=MIME.APPLICATION_JSON,
+            ),
+        ]
+        mock_subscribe.return_value = async_iter(events)
+        recv = []
+        async for event in ensign.subscribe("otters", "lighthouses"):
+            recv.append(event)
+            if len(recv) == 2:
+                break
+        assert recv[0].data == events[0].data
+        assert recv[1].data == events[1].data
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.list_topics")
+    async def test_get_topics(self, mock_list, ensign):
+        topics = [topic_pb2.Topic(id=ULID().bytes, name="otters")]
+        mock_list.return_value = (topics, "")
+        recv = await ensign.get_topics()
+        assert recv[0].name == topics[0].name
+
+        # TODO: test pagination
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.create_topic")
+    async def test_create_topic(self, mock_create, ensign):
+        id = ULID().bytes
+        mock_create.return_value = topic_pb2.Topic(id=id, name="otters")
+        topic = await ensign.create_topic("otters")
+        assert topic.id == id
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.create_topic")
+    async def test_create_topic_error(self, mock_create, ensign):
+        mock_create.return_value = None
+        with pytest.raises(EnsignTopicCreateError):
+            await ensign.create_topic("otters")
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.destroy_topic")
+    async def test_destroy_topic(self, mock_destroy, ensign):
+        mock_destroy.return_value = (
+            ULID().bytes,
+            topic_pb2.TopicTombstone.Status.DELETING,
+        )
+        success = await ensign.destroy_topic("otters")
+        assert success
+
+    @pytest.mark.asyncio
+    @patch("pyensign.connection.Client.destroy_topic")
+    async def test_destroy_topic_error(self, mock_destroy, ensign):
+        mock_destroy.return_value = (
+            ULID().bytes,
+            topic_pb2.TopicTombstone.Status.UNKNOWN,
+        )
+        success = await ensign.destroy_topic("otters")
+        assert not success
+
+    @pytest.mark.asyncio
     async def test_live_pubsub(self, live, authserver, ensignserver):
         if not live:
             pytest.skip("Skipping live test")
@@ -75,41 +217,27 @@ class TestEnsign:
             pytest.skip("Skipping live test")
 
         ensign = Ensign(endpoint=ensignserver, auth_url=authserver)
+        event = Event(b"message in a bottle", "TEXT_PLAIN")
+        topic = "pyensign-pub-sub"
 
-        # Get or create the topic
-        name = "pyensign-pub-sub"
-        topic_id = ""
-        if not await ensign.topic_exists(name):
-            topic = topic_pb2.Topic(name=name)
+        # Ensure the topic exists
+        if not await ensign.topic_exists(topic):
             await ensign.create_topic(topic)
-            topic_id = str(ULID.from_bytes(topic.id))
-        else:
-            topics = await ensign.get_topics()
-            for t in topics:
-                if t.name == name:
-                    topic_id = str(ULID.from_bytes(t.id))
-                    break
-
-        # Create an event
-        data = json.dumps({"foo": "bar"}).encode("utf-8")
-        type = event_pb2.Type(name="Generic", version=1)
-        event = event_pb2.Event(
-            topic_id=topic_id, data=data, mimetype=MIME.APPLICATION_JSON, type=type
-        )
 
         # Run publish and subscribe as coroutines
         async def pub():
             # Delay the publisher to prevent deadlock
             await asyncio.sleep(1)
-            return await ensign.publish(iter([event]))
+            return await ensign.publish(topic, event)
 
         async def sub():
-            async for event in ensign.subscribe([topic_id]):
+            id = await ensign.topic_id(topic)
+            async for event in ensign.subscribe(id):
                 return event
 
         errors, event = await asyncio.gather(pub(), sub())
         assert len(errors) == 0
-        assert event.data == data
-        assert event.mimetype == MIME.APPLICATION_JSON
+        assert event.data == b"message in a bottle"
+        assert event.mimetype == MIME.TEXT_PLAIN
         assert event.type.name == "Generic"
         assert event.type.version == 1

--- a/tests/pyensign/test_ensign.py
+++ b/tests/pyensign/test_ensign.py
@@ -1,6 +1,4 @@
 import os
-import mmh3
-import base64
 import pytest
 import asyncio
 from ulid import ULID

--- a/tests/pyensign/test_events.py
+++ b/tests/pyensign/test_events.py
@@ -1,0 +1,37 @@
+import pytest
+
+from pyensign.events import Event
+from pyensign.events import mimetypes
+from pyensign.mimetype.v1beta1.mimetype_pb2 import MIME
+
+
+class TestEvent:
+    """
+    Test cases for the Event helper class.
+    """
+
+    @pytest.mark.parametrize(
+        "mimetype, expected",
+        [
+            (MIME.APPLICATION_JSON, MIME.APPLICATION_JSON),
+            (MIME.TEXT_PLAIN, MIME.TEXT_PLAIN),
+            (MIME.TEXT_HTML, MIME.TEXT_HTML),
+            ("APPLICATION_JSON", MIME.APPLICATION_JSON),
+            ("TEXT_PLAIN", MIME.TEXT_PLAIN),
+            ("TEXT_HTML", MIME.TEXT_HTML),
+        ],
+    )
+    def test_event(self, mimetype, expected):
+        data = b"test"
+        event = Event(data=data, mimetype=mimetype)
+        assert event.data == data
+        assert event.mimetype == expected
+        assert event.type.name == "Generic"
+        assert event.type.version == 1
+
+        proto = event.proto(topic_id="topic")
+        assert proto.topic_id == "topic"
+        assert proto.data == data
+        assert proto.mimetype == expected
+        assert proto.type.name == "Generic"
+        assert proto.type.version == 1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+asyncmock==0.4.2
 attrs==22.2.0
 certifi==2022.12.7
 charset-normalizer==3.1.0


### PR DESCRIPTION
This updates the publish and subscribe interface for usability:

- Added an Event helper class
- Publish accepts an iterable of events
- Publish attempts to create topics that don't exist
- Subscribe accepts one or more topics
- Updated docs with usage examples