### PR TITLE
Support IETF mimetypes

### DIFF
--- a/pyensign/api/v1beta1/event_pb2.py
+++ b/pyensign/api/v1beta1/event_pb2.py
@@ -20,7 +20,7 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x17\x61pi/v1beta1/event.proto\x12\x0e\x65nsign.v1beta1\x1a\x1bregion/v1beta1/region.proto\x1a\x1fmimetype/v1beta1/mimetype.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xdd\x02\n\x0c\x45ventWrapper\x12\n\n\x02id\x18\x01 \x01(\x0c\x12\x10\n\x08topic_id\x18\x02 \x01(\x0c\x12\x0e\n\x06offset\x18\x03 \x01(\x04\x12\r\n\x05\x65poch\x18\x04 \x01(\x04\x12&\n\x06region\x18\x05 \x01(\x0e\x32\x16.region.v1beta1.Region\x12,\n\tpublisher\x18\x06 \x01(\x0b\x32\x19.ensign.v1beta1.Publisher\x12\x0b\n\x03key\x18\x07 \x01(\x0c\x12\r\n\x05shard\x18\x08 \x01(\x04\x12\r\n\x05\x65vent\x18\t \x01(\x0c\x12.\n\nencryption\x18\n \x01(\x0b\x32\x1a.ensign.v1beta1.Encryption\x12\x30\n\x0b\x63ompression\x18\x0b \x01(\x0b\x32\x1b.ensign.v1beta1.Compression\x12-\n\tcommitted\x18\x0f \x01(\x0b\x32\x1a.google.protobuf.Timestamp"\x91\x02\n\x05\x45vent\x12\x17\n\x0fuser_defined_id\x18\x01 \x01(\t\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\x12\x35\n\x08metadata\x18\x03 \x03(\x0b\x32#.ensign.v1beta1.Event.MetadataEntry\x12(\n\x08mimetype\x18\x04 \x01(\x0e\x32\x16.mimetype.v1beta1.MIME\x12"\n\x04type\x18\x05 \x01(\x0b\x32\x14.ensign.v1beta1.Type\x12+\n\x07\x63reated\x18\x0f \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"\xe3\x07\n\x0e\x45ventContainer\x12\x10\n\x08topic_id\x18\x01 \x01(\x0c\x12\x14\n\x0cstart_offset\x18\x02 \x01(\x04\x12\x12\n\nend_offset\x18\x03 \x01(\x04\x12:\n\x06\x65pochs\x18\x04 \x03(\x0b\x32*.ensign.v1beta1.EventContainer.EpochsEntry\x12\x0e\n\x06\x65vents\x18\x05 \x01(\x0c\x12.\n\nencryption\x18\x06 \x01(\x0b\x32\x1a.ensign.v1beta1.Encryption\x12\x30\n\x0b\x63ompression\x18\x07 \x01(\x0b\x32\x1b.ensign.v1beta1.Compression\x12\'\n\x07regions\x18\x08 \x03(\x0e\x32\x16.region.v1beta1.Region\x12\x45\n\x0cregion_index\x18\t \x03(\x0b\x32/.ensign.v1beta1.EventContainer.RegionIndexEntry\x12-\n\npublishers\x18\n \x03(\x0b\x32\x19.ensign.v1beta1.Publisher\x12K\n\x0fpublisher_index\x18\x0b \x03(\x0b\x32\x32.ensign.v1beta1.EventContainer.PublisherIndexEntry\x12\x0c\n\x04keys\x18\x0c \x03(\x0c\x12?\n\tkey_index\x18\r \x03(\x0b\x32,.ensign.v1beta1.EventContainer.KeyIndexEntry\x12\x0e\n\x06shards\x18\x0e \x03(\x04\x12\x43\n\x0bshard_index\x18\x0f \x03(\x0b\x32..ensign.v1beta1.EventContainer.ShardIndexEntry\x12+\n\x07\x63reated\x18\x1f \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08modified\x18  \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a-\n\x0b\x45pochsEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\x04:\x02\x38\x01\x1a\x32\n\x10RegionIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a\x35\n\x13PublisherIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a/\n\rKeyIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a\x31\n\x0fShardIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01"Y\n\x04Type\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rmajor_version\x18\x02 \x01(\r\x12\x15\n\rminor_version\x18\x03 \x01(\r\x12\x15\n\rpatch_version\x18\x04 \x01(\r"\xa0\x03\n\nEncryption\x12\x15\n\rpublic_key_id\x18\x01 \x01(\t\x12\x16\n\x0e\x65ncryption_key\x18\x02 \x01(\x0c\x12\x13\n\x0bhmac_secret\x18\x03 \x01(\x0c\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12?\n\x11sealing_algorithm\x18\x05 \x01(\x0e\x32$.ensign.v1beta1.Encryption.Algorithm\x12\x42\n\x14\x65ncryption_algorithm\x18\x06 \x01(\x0e\x32$.ensign.v1beta1.Encryption.Algorithm\x12\x41\n\x13signature_algorithm\x18\x07 \x01(\x0e\x32$.ensign.v1beta1.Encryption.Algorithm"s\n\tAlgorithm\x12\r\n\tPLAINTEXT\x10\x00\x12\x0e\n\nAES256_GCM\x10n\x12\x0e\n\nAES192_GCM\x10x\x12\x0f\n\nAES128_GCM\x10\x82\x01\x12\x10\n\x0bHMAC_SHA256\x10\xb6\x02\x12\x14\n\x0fRSA_OAEP_SHA512\x10\xfe\x03"\x9e\x01\n\x0b\x43ompression\x12\x38\n\talgorithm\x18\x01 \x01(\x0e\x32%.ensign.v1beta1.Compression.Algorithm\x12\r\n\x05level\x18\x02 \x01(\x03"F\n\tAlgorithm\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04GZIP\x10\x01\x12\x0c\n\x08\x43OMPRESS\x10\x02\x12\x0b\n\x07\x44\x45\x46LATE\x10\x03\x12\n\n\x06\x42ROTLI\x10\x04"X\n\tPublisher\x12\x14\n\x0cpublisher_id\x18\x01 \x01(\t\x12\x0e\n\x06ipaddr\x18\x02 \x01(\t\x12\x11\n\tclient_id\x18\x03 \x01(\t\x12\x12\n\nuser_agent\x18\x04 \x01(\tb\x06proto3'
+    b'\n\x17\x61pi/v1beta1/event.proto\x12\x0e\x65nsign.v1beta1\x1a\x1bregion/v1beta1/region.proto\x1a\x1fmimetype/v1beta1/mimetype.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xef\x02\n\x0c\x45ventWrapper\x12\n\n\x02id\x18\x01 \x01(\x0c\x12\x10\n\x08topic_id\x18\x02 \x01(\x0c\x12\x0e\n\x06offset\x18\x03 \x01(\x04\x12\r\n\x05\x65poch\x18\x04 \x01(\x04\x12&\n\x06region\x18\x05 \x01(\x0e\x32\x16.region.v1beta1.Region\x12,\n\tpublisher\x18\x06 \x01(\x0b\x32\x19.ensign.v1beta1.Publisher\x12\x0b\n\x03key\x18\x07 \x01(\x0c\x12\r\n\x05shard\x18\x08 \x01(\x04\x12\r\n\x05\x65vent\x18\t \x01(\x0c\x12.\n\nencryption\x18\n \x01(\x0b\x32\x1a.ensign.v1beta1.Encryption\x12\x30\n\x0b\x63ompression\x18\x0b \x01(\x0b\x32\x1b.ensign.v1beta1.Compression\x12-\n\tcommitted\x18\x0f \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x10\n\x08local_id\x18\x10 \x01(\x0c"\xf8\x01\n\x05\x45vent\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\x12\x35\n\x08metadata\x18\x03 \x03(\x0b\x32#.ensign.v1beta1.Event.MetadataEntry\x12(\n\x08mimetype\x18\x04 \x01(\x0e\x32\x16.mimetype.v1beta1.MIME\x12"\n\x04type\x18\x05 \x01(\x0b\x32\x14.ensign.v1beta1.Type\x12+\n\x07\x63reated\x18\x0f \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"\xe3\x07\n\x0e\x45ventContainer\x12\x10\n\x08topic_id\x18\x01 \x01(\x0c\x12\x14\n\x0cstart_offset\x18\x02 \x01(\x04\x12\x12\n\nend_offset\x18\x03 \x01(\x04\x12:\n\x06\x65pochs\x18\x04 \x03(\x0b\x32*.ensign.v1beta1.EventContainer.EpochsEntry\x12\x0e\n\x06\x65vents\x18\x05 \x01(\x0c\x12.\n\nencryption\x18\x06 \x01(\x0b\x32\x1a.ensign.v1beta1.Encryption\x12\x30\n\x0b\x63ompression\x18\x07 \x01(\x0b\x32\x1b.ensign.v1beta1.Compression\x12\'\n\x07regions\x18\x08 \x03(\x0e\x32\x16.region.v1beta1.Region\x12\x45\n\x0cregion_index\x18\t \x03(\x0b\x32/.ensign.v1beta1.EventContainer.RegionIndexEntry\x12-\n\npublishers\x18\n \x03(\x0b\x32\x19.ensign.v1beta1.Publisher\x12K\n\x0fpublisher_index\x18\x0b \x03(\x0b\x32\x32.ensign.v1beta1.EventContainer.PublisherIndexEntry\x12\x0c\n\x04keys\x18\x0c \x03(\x0c\x12?\n\tkey_index\x18\r \x03(\x0b\x32,.ensign.v1beta1.EventContainer.KeyIndexEntry\x12\x0e\n\x06shards\x18\x0e \x03(\x04\x12\x43\n\x0bshard_index\x18\x0f \x03(\x0b\x32..ensign.v1beta1.EventContainer.ShardIndexEntry\x12+\n\x07\x63reated\x18\x1f \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08modified\x18  \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a-\n\x0b\x45pochsEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\x04:\x02\x38\x01\x1a\x32\n\x10RegionIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a\x35\n\x13PublisherIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a/\n\rKeyIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a\x31\n\x0fShardIndexEntry\x12\x0b\n\x03key\x18\x01 \x01(\r\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01"Y\n\x04Type\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rmajor_version\x18\x02 \x01(\r\x12\x15\n\rminor_version\x18\x03 \x01(\r\x12\x15\n\rpatch_version\x18\x04 \x01(\r"\xa0\x03\n\nEncryption\x12\x15\n\rpublic_key_id\x18\x01 \x01(\t\x12\x16\n\x0e\x65ncryption_key\x18\x02 \x01(\x0c\x12\x13\n\x0bhmac_secret\x18\x03 \x01(\x0c\x12\x11\n\tsignature\x18\x04 \x01(\x0c\x12?\n\x11sealing_algorithm\x18\x05 \x01(\x0e\x32$.ensign.v1beta1.Encryption.Algorithm\x12\x42\n\x14\x65ncryption_algorithm\x18\x06 \x01(\x0e\x32$.ensign.v1beta1.Encryption.Algorithm\x12\x41\n\x13signature_algorithm\x18\x07 \x01(\x0e\x32$.ensign.v1beta1.Encryption.Algorithm"s\n\tAlgorithm\x12\r\n\tPLAINTEXT\x10\x00\x12\x0e\n\nAES256_GCM\x10n\x12\x0e\n\nAES192_GCM\x10x\x12\x0f\n\nAES128_GCM\x10\x82\x01\x12\x10\n\x0bHMAC_SHA256\x10\xb6\x02\x12\x14\n\x0fRSA_OAEP_SHA512\x10\xfe\x03"\x9e\x01\n\x0b\x43ompression\x12\x38\n\talgorithm\x18\x01 \x01(\x0e\x32%.ensign.v1beta1.Compression.Algorithm\x12\r\n\x05level\x18\x02 \x01(\x03"F\n\tAlgorithm\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04GZIP\x10\x01\x12\x0c\n\x08\x43OMPRESS\x10\x02\x12\x0b\n\x07\x44\x45\x46LATE\x10\x03\x12\n\n\x06\x42ROTLI\x10\x04"X\n\tPublisher\x12\x14\n\x0cpublisher_id\x18\x01 \x01(\t\x12\x0e\n\x06ipaddr\x18\x02 \x01(\t\x12\x11\n\tclient_id\x18\x03 \x01(\t\x12\x12\n\nuser_agent\x18\x04 \x01(\tb\x06proto3'
 )
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
@@ -41,33 +41,33 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _EVENTCONTAINER_SHARDINDEXENTRY._options = None
     _EVENTCONTAINER_SHARDINDEXENTRY._serialized_options = b"8\001"
     _EVENTWRAPPER._serialized_start = 139
-    _EVENTWRAPPER._serialized_end = 488
-    _EVENT._serialized_start = 491
-    _EVENT._serialized_end = 764
-    _EVENT_METADATAENTRY._serialized_start = 717
-    _EVENT_METADATAENTRY._serialized_end = 764
-    _EVENTCONTAINER._serialized_start = 767
-    _EVENTCONTAINER._serialized_end = 1762
-    _EVENTCONTAINER_EPOCHSENTRY._serialized_start = 1510
-    _EVENTCONTAINER_EPOCHSENTRY._serialized_end = 1555
-    _EVENTCONTAINER_REGIONINDEXENTRY._serialized_start = 1557
-    _EVENTCONTAINER_REGIONINDEXENTRY._serialized_end = 1607
-    _EVENTCONTAINER_PUBLISHERINDEXENTRY._serialized_start = 1609
-    _EVENTCONTAINER_PUBLISHERINDEXENTRY._serialized_end = 1662
-    _EVENTCONTAINER_KEYINDEXENTRY._serialized_start = 1664
-    _EVENTCONTAINER_KEYINDEXENTRY._serialized_end = 1711
-    _EVENTCONTAINER_SHARDINDEXENTRY._serialized_start = 1713
-    _EVENTCONTAINER_SHARDINDEXENTRY._serialized_end = 1762
-    _TYPE._serialized_start = 1764
-    _TYPE._serialized_end = 1853
-    _ENCRYPTION._serialized_start = 1856
-    _ENCRYPTION._serialized_end = 2272
-    _ENCRYPTION_ALGORITHM._serialized_start = 2157
-    _ENCRYPTION_ALGORITHM._serialized_end = 2272
-    _COMPRESSION._serialized_start = 2275
-    _COMPRESSION._serialized_end = 2433
-    _COMPRESSION_ALGORITHM._serialized_start = 2363
-    _COMPRESSION_ALGORITHM._serialized_end = 2433
-    _PUBLISHER._serialized_start = 2435
-    _PUBLISHER._serialized_end = 2523
+    _EVENTWRAPPER._serialized_end = 506
+    _EVENT._serialized_start = 509
+    _EVENT._serialized_end = 757
+    _EVENT_METADATAENTRY._serialized_start = 710
+    _EVENT_METADATAENTRY._serialized_end = 757
+    _EVENTCONTAINER._serialized_start = 760
+    _EVENTCONTAINER._serialized_end = 1755
+    _EVENTCONTAINER_EPOCHSENTRY._serialized_start = 1503
+    _EVENTCONTAINER_EPOCHSENTRY._serialized_end = 1548
+    _EVENTCONTAINER_REGIONINDEXENTRY._serialized_start = 1550
+    _EVENTCONTAINER_REGIONINDEXENTRY._serialized_end = 1600
+    _EVENTCONTAINER_PUBLISHERINDEXENTRY._serialized_start = 1602
+    _EVENTCONTAINER_PUBLISHERINDEXENTRY._serialized_end = 1655
+    _EVENTCONTAINER_KEYINDEXENTRY._serialized_start = 1657
+    _EVENTCONTAINER_KEYINDEXENTRY._serialized_end = 1704
+    _EVENTCONTAINER_SHARDINDEXENTRY._serialized_start = 1706
+    _EVENTCONTAINER_SHARDINDEXENTRY._serialized_end = 1755
+    _TYPE._serialized_start = 1757
+    _TYPE._serialized_end = 1846
+    _ENCRYPTION._serialized_start = 1849
+    _ENCRYPTION._serialized_end = 2265
+    _ENCRYPTION_ALGORITHM._serialized_start = 2150
+    _ENCRYPTION_ALGORITHM._serialized_end = 2265
+    _COMPRESSION._serialized_start = 2268
+    _COMPRESSION._serialized_end = 2426
+    _COMPRESSION_ALGORITHM._serialized_start = 2356
+    _COMPRESSION_ALGORITHM._serialized_end = 2426
+    _PUBLISHER._serialized_start = 2428
+    _PUBLISHER._serialized_end = 2516
 # @@protoc_insertion_point(module_scope)

--- a/pyensign/events.py
+++ b/pyensign/events.py
@@ -11,7 +11,7 @@ class Event:
     create and parse events.
     """
 
-    def __init__(self, data=None, mimetype=None, meta={}):
+    def __init__(self, data=None, mimetype=mtype.ApplicationJSON, meta={}):
         """
         Create a new Event from a mimetype and data.
 

--- a/pyensign/events.py
+++ b/pyensign/events.py
@@ -1,11 +1,8 @@
 import time
 from google.protobuf.timestamp_pb2 import Timestamp
 
+from pyensign import mimetypes as mtype
 from pyensign.api.v1beta1 import event_pb2
-from pyensign.mimetype.v1beta1 import mimetype_pb2
-
-mimetypes = mimetype_pb2.DESCRIPTOR.enum_types_by_name["MIME"].values_by_name
-mimetype_names = mimetypes.keys()
 
 
 class Event:
@@ -23,7 +20,7 @@ class Event:
         data : bytes
             The data to use for the event.
         mimetype: str or int
-            The mimetype of the data (e.g. "APPLICATION_JSON").
+            The mimetype of the data (e.g. "application/json").
         id : str (optional)
             A user-defined ID for the event.
         meta: dict (optional)
@@ -33,18 +30,10 @@ class Event:
         if not data:
             raise ValueError("no data provided")
 
-        if not mimetype:
+        if mimetype is None:
             raise ValueError("no mimetype provided")
 
-        # TODO: Support traditionally formatted mimetypes (e.g. application/json)
-        if isinstance(mimetype, str):
-            if mimetype not in mimetypes:
-                raise ValueError(
-                    "invalid mimetype, specify one of: {}".format(mimetype_names)
-                )
-            self.mimetype = mimetypes[mimetype].number
-        else:
-            self.mimetype = mimetype
+        self.mimetype = mtype.parse(mimetype)
 
         # Fields that the user may want to modify after creation.
         self.id = id

--- a/pyensign/events.py
+++ b/pyensign/events.py
@@ -11,7 +11,7 @@ class Event:
     create and parse events.
     """
 
-    def __init__(self, data=None, mimetype=None, id="", meta={}):
+    def __init__(self, data=None, mimetype=None, meta={}):
         """
         Create a new Event from a mimetype and data.
 
@@ -21,8 +21,6 @@ class Event:
             The data to use for the event.
         mimetype: str or int
             The mimetype of the data (e.g. "application/json").
-        id : str (optional)
-            A user-defined ID for the event.
         meta: dict (optional)
             A set of key-value pairs to associate with the event.
         """
@@ -36,7 +34,6 @@ class Event:
         self.mimetype = mtype.parse(mimetype)
 
         # Fields that the user may want to modify after creation.
-        self.id = id
         self.data = data
         self.meta = meta
         self.type = event_pb2.Type(
@@ -60,7 +57,6 @@ class Event:
 
         # TODO: Should we raise type errors and missing field errors to help the user?
         return event_pb2.Event(
-            user_defined_id=self.id,
             data=self.data,
             metadata=self.meta,
             mimetype=self.mimetype,

--- a/pyensign/mimetypes.py
+++ b/pyensign/mimetypes.py
@@ -1,0 +1,168 @@
+import re
+
+from pyensign.mimetype.v1beta1 import mimetype_pb2 as mt
+
+# Expose more readable mimetype aliases for developers.
+Unspecified = mt.UNSPECIFIED
+Unknown = mt.UNKNOWN
+TextPlain = mt.TEXT_PLAIN
+TextCSV = mt.TEXT_CSV
+TextHTML = mt.TEXT_HTML
+TextCalendar = mt.TEXT_CALENDAR
+ApplicationOctetStream = mt.APPLICATION_OCTET_STREAM
+ApplicationJSON = mt.APPLICATION_JSON
+ApplicationJSONUTF8 = mt.APPLICATION_JSON_UTF8
+ApplicationJSONLD = mt.APPLICATION_JSON_LD
+AppplicationJSONLines = mt.APPLICATION_JSON_LINES
+ApplicationUBJSON = mt.APPLICATION_UBJSON
+ApplicationBSON = mt.APPLICATION_BSON
+ApplicationXML = mt.APPLICATION_XML
+ApplicationAtom = mt.APPLICATION_ATOM
+ApplicationMsgPack = mt.APPLICATION_MSGPACK
+ApplicationParquet = mt.APPLICATION_PARQUET
+ApplicationAvro = mt.APPLICATION_AVRO
+ApplicationProtobuf = mt.APPLICATION_PROTOBUF
+ApplicationPDF = mt.APPLICATION_PDF
+ApplicationJavaArchive = mt.APPLICATION_JAVA_ARCHIVE
+ApplicationPythonPickle = mt.APPLICATION_PYTHON_PICKLE
+UserSpecified0 = mt.USER_SPECIFIED0
+UserSpecified1 = mt.USER_SPECIFIED1
+UserSpecified2 = mt.USER_SPECIFIED2
+UserSpecified3 = mt.USER_SPECIFIED3
+UserSpecified4 = mt.USER_SPECIFIED4
+UserSpecified5 = mt.USER_SPECIFIED5
+UserSpecified6 = mt.USER_SPECIFIED6
+UserSpecified7 = mt.USER_SPECIFIED7
+UserSpecified8 = mt.USER_SPECIFIED8
+UserSpecified9 = mt.USER_SPECIFIED9
+
+# Map the mimetype integer value to the string defined by the IETF spec.
+# https://www.iana.org/assignments/media-types/media-types.xhtml
+names_by_value = {
+    0: "application/octet-stream",
+    1: "text/plain",
+    2: "text/csv",
+    3: "text/html",
+    4: "text/calendar",
+    50: "application/json",
+    51: "application/ld+json",
+    52: "application/jsonlines",
+    53: "application/ubjson",
+    54: "application/bson",
+    100: "application/xml",
+    101: "application/atom+xml",
+    252: "application/msgpack",
+    253: "application/parquet",
+    254: "application/avro",
+    255: "application/protobuf",
+    512: "application/pdf",
+    513: "application/java-archive",
+    514: "application/python-pickle",
+    1000: "user/format-0",
+    1001: "user/format-1",
+    1002: "user/format-2",
+    1003: "user/format-3",
+    1004: "user/format-4",
+    1005: "user/format-5",
+    1006: "user/format-6",
+    1007: "user/format-7",
+    1008: "user/format-8",
+    1009: "user/format-9",
+}
+
+# Map the IETF string to the integer value defined by the protocol buffers.
+values_by_name = {v: k for k, v in names_by_value.items()}
+
+# Parse a mimetype as a dictionary of its components using the format:
+# prefix/mime+ext; key1=value1; key2=value2. Pairs will include the leading semicolon
+# and whitespace between keys and values.
+_mimetype_pattern = re.compile(
+    r"^(?P<prefix>application|user|text)\/(?P<mime>[\w\-_\.]+)(\+(?P<ext>[\w-]+))?(?P<pairs>;(\s+([\w\.\-_]+=[\w\.\-_]+))+)?$"
+)
+
+
+def _parse_str(mimetype):
+    match = _mimetype_pattern.search(mimetype)
+    if not match:
+        raise ValueError("unparseable mimetype: {}".format(mimetype))
+    return match.groupdict()
+
+
+def _build(prefix, mime, ext="", pairs=""):
+    """
+    Build a mimetype string from its components.
+    """
+
+    if ext:
+        ext = "+" + ext
+
+    return "{}/{}{}{}".format(prefix, mime, ext, pairs)
+
+
+def parse(mimetype):
+    """
+    Parse a mimetype from a string or integer and return a standardized value that
+    represents the mimetype. This method uses a best effort approach in order to match
+    the given mimetype to an IETF standard mimetype. For example,
+    application/vnd.myapp.type+xml will be matched to application/xml.
+
+    Parameters
+    ----------
+    mimetype : str or int
+        The mimetype to parse.
+
+    Returns
+    -------
+    int
+        The protocol buffer representation of the mimetype.
+
+    Raises
+    ------
+    ValueError
+        If the mimetype is not recognized.
+    """
+
+    # Just attempt a lookup if the mimetype doesn't need to be parsed.
+    if not isinstance(mimetype, str):
+        if mimetype in names_by_value:
+            return mimetype
+        raise ValueError("unrecognized mimetype: {}".format(mimetype))
+
+    # First try to match the mimetype exactly.
+    s = mimetype.lower().strip()
+    if s in values_by_name:
+        return values_by_name[s]
+
+    # Parse the mimetype into its components.
+    components = _parse_str(mimetype)
+
+    # Try to match against just the prefix and mime.
+    m = _build(components["prefix"], components["mime"])
+    if m in values_by_name:
+        return values_by_name[m]
+
+    # Try to match against the prefix, mime, and extension.
+    m = _build(components["prefix"], components["mime"], ext=components["ext"])
+    if m in values_by_name:
+        return values_by_name[m]
+
+    # Try to match using the extension for the mime type.
+    m = _build(components["prefix"], components["ext"])
+    if m in values_by_name:
+        return values_by_name[m]
+
+    # Try matching against the alternate prefix.
+    prefix = "application" if components["prefix"] == "text" else "text"
+    m = _build(prefix, components["mime"])
+    if m in values_by_name:
+        return values_by_name[m]
+
+    m = _build(prefix, components["mime"], ext=components["ext"])
+    if m in values_by_name:
+        return values_by_name[m]
+
+    m = _build(prefix, components["ext"])
+    if m in values_by_name:
+        return values_by_name[m]
+
+    raise ValueError("unrecognized mimetype: {}".format(mimetype))

--- a/tests/pyensign/api/v1beta1/test_event.py
+++ b/tests/pyensign/api/v1beta1/test_event.py
@@ -12,7 +12,6 @@ from pyensign.mimetype.v1beta1.mimetype_pb2 import MIME
 @pytest.fixture
 def event():
     return event_pb2.Event(
-        user_defined_id="1",
         data=b"some data",
         metadata={"key": "value"},
         mimetype=MIME.APPLICATION_JSON,
@@ -37,9 +36,7 @@ def test_wrap(event):
     assert ew.event == event.SerializeToString()
     assert ew.topic_id == topic_id.bytes
 
-    event = event_pb2.Event(
-        user_defined_id="1",
-    )
+    event = event_pb2.Event()
     ew = wrap(event, topic_id)
 
 

--- a/tests/pyensign/test_connection.py
+++ b/tests/pyensign/test_connection.py
@@ -211,8 +211,8 @@ class TestClient:
 
     async def test_publish(self, client):
         events = [
-            event_pb2.Event(user_defined_id="1"),
-            event_pb2.Event(user_defined_id="2"),
+            event_pb2.Event(),
+            event_pb2.Event(),
         ]
         async for rep in client.publish(ULID(), iter(events)):
             assert isinstance(rep, ensign_pb2.Ack)
@@ -223,8 +223,8 @@ class TestClient:
 
     async def test_pub_sub(self, client):
         events = [
-            event_pb2.Event(user_defined_id="1"),
-            event_pb2.Event(user_defined_id="2"),
+            event_pb2.Event(),
+            event_pb2.Event(),
         ]
         async for rep in client.publish(ULID(), iter(events)):
             await asyncio.sleep(0.01)

--- a/tests/pyensign/test_ensign.py
+++ b/tests/pyensign/test_ensign.py
@@ -160,12 +160,10 @@ class TestEnsign:
     async def test_subscribe(self, mock_subscribe, ensign):
         events = [
             event_pb2.Event(
-                user_defined_id="1",
                 data=b'{"foo": "bar"}',
                 mimetype=MIME.APPLICATION_JSON,
             ),
             event_pb2.Event(
-                user_defined_id="2",
                 data=b'{"bar": "bz"}',
                 mimetype=MIME.APPLICATION_JSON,
             ),

--- a/tests/pyensign/test_events.py
+++ b/tests/pyensign/test_events.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pyensign.events import Event
-from pyensign.events import mimetypes
+from pyensign import mimetypes as mt
 from pyensign.mimetype.v1beta1.mimetype_pb2 import MIME
 from pyensign.api.v1beta1 import event_pb2
 
@@ -14,12 +14,14 @@ class TestEvent:
     @pytest.mark.parametrize(
         "mimetype, expected",
         [
-            (MIME.APPLICATION_JSON, MIME.APPLICATION_JSON),
+            (MIME.APPLICATION_XML, MIME.APPLICATION_XML),
             (MIME.TEXT_PLAIN, MIME.TEXT_PLAIN),
             (MIME.TEXT_HTML, MIME.TEXT_HTML),
-            ("APPLICATION_JSON", MIME.APPLICATION_JSON),
-            ("TEXT_PLAIN", MIME.TEXT_PLAIN),
-            ("TEXT_HTML", MIME.TEXT_HTML),
+            ("application/json", MIME.APPLICATION_JSON),
+            ("text/plain", MIME.TEXT_PLAIN),
+            ("text/html", MIME.TEXT_HTML),
+            (0, MIME.APPLICATION_OCTET_STREAM),
+            (100, MIME.APPLICATION_XML),
         ],
     )
     def test_event(self, mimetype, expected):
@@ -47,7 +49,7 @@ class TestEvent:
         protobuf.
         """
 
-        event = Event(data=b"test", mimetype=MIME.TEXT_PLAIN)
+        event = Event(data=b"test", mimetype=mt.TextPlain)
         proto = event._proto
         assert proto.data == b"test"
         assert proto.mimetype == MIME.TEXT_PLAIN
@@ -73,4 +75,4 @@ class TestEvent:
         """
 
         with pytest.raises(TypeError):
-            Event(data="notbytes", mimetype=MIME.TEXT_PLAIN)
+            Event(data="notbytes", mimetype=mt.TextPlain)

--- a/tests/pyensign/test_mimetypes.py
+++ b/tests/pyensign/test_mimetypes.py
@@ -1,0 +1,178 @@
+import pytest
+
+from pyensign import mimetypes as mt
+from pyensign.mimetype.v1beta1 import mimetype_pb2
+
+
+def test_mimetypes():
+    """
+    Test that all mimetypes in the protobufs are defined in the Python code and vice
+    versa.
+    """
+
+    proto_mimetypes = mimetype_pb2.DESCRIPTOR.enum_types_by_name["MIME"].values_by_name
+    proto_values = [v.number for v in proto_mimetypes.values()]
+
+    for value in proto_values:
+        assert value in mt.names_by_value
+
+    for value in mt.names_by_value:
+        assert value in proto_values
+
+    # Ensure both Python maps have the same entries
+    for name, value in mt.values_by_name.items():
+        assert value in mt.names_by_value
+        assert mt.names_by_value[value] == name
+
+    for value, name in mt.names_by_value.items():
+        assert name in mt.values_by_name
+        assert mt.values_by_name[name] == value
+
+    assert len(mt.names_by_value) == len(mt.values_by_name)
+
+
+@pytest.mark.parametrize(
+    "mimetype,expected",
+    [
+        (0, mt.ApplicationOctetStream),
+        (100, mt.ApplicationXML),
+        ("application/json", mt.ApplicationJSON),
+        ("user/format-5", mt.UserSpecified5),
+        ("APPLICATION/XML", mt.ApplicationXML),
+        ("  TEXT/csv  ", mt.TextCSV),
+        ("application/json; charset=utf-8", mt.ApplicationJSON),
+        ("application/atom+xml; charset=latin1", mt.ApplicationAtom),
+        ("application/vnd.myapp.type+xml", mt.ApplicationXML),
+        ("text/atom+xml", mt.ApplicationAtom),
+        ("application/csv", mt.TextCSV),
+        ("text/vnd.myapp.type+xml", mt.ApplicationXML),
+    ],
+)
+def test_parse(mimetype, expected):
+    """
+    Test that valid mimetypes are parsed into the correct enums.
+    """
+
+    assert mt.parse(mimetype) == expected
+
+
+@pytest.mark.parametrize(
+    "mimetype",
+    [
+        (None),
+        (99999),
+        ("text/svg+png"),
+        ("image/png"),
+        ("application/vnd.myapp.type"),
+    ],
+)
+def test_parse_invalid(mimetype):
+    """
+    Test that invalid mimetypes raise a ValueError.
+    """
+
+    with pytest.raises(ValueError):
+        mt.parse(mimetype)
+
+
+def test_prefixes():
+    """
+    Test that prefix constants are spelled correctly.
+    """
+
+    prefixes = ["application", "text", "user"]
+    for _, name in mt.names_by_value.items():
+        parts = name.split("/")
+        assert len(parts) == 2
+        assert parts[0] in prefixes
+
+
+@pytest.mark.parametrize(
+    "mimetype,expected",
+    [
+        (
+            "application/json",
+            {"prefix": "application", "mime": "json", "ext": None, "pairs": None},
+        ),
+        (
+            "application/ld+json",
+            {"prefix": "application", "mime": "ld", "ext": "json", "pairs": None},
+        ),
+        (
+            "application/json; charset=utf8",
+            {
+                "prefix": "application",
+                "mime": "json",
+                "pairs": "; charset=utf8",
+                "ext": None,
+            },
+        ),
+        (
+            "application/protobuf; msg=trisa.v1beta1.SecureEnvelope counterparty=trisa.example.com",
+            {
+                "prefix": "application",
+                "mime": "protobuf",
+                "pairs": "; msg=trisa.v1beta1.SecureEnvelope counterparty=trisa.example.com",
+                "ext": None,
+            },
+        ),
+        (
+            "application/atom+xml; charset=utf-8",
+            {
+                "prefix": "application",
+                "mime": "atom",
+                "ext": "xml",
+                "pairs": "; charset=utf-8",
+            },
+        ),
+        (
+            "application/vnd.google.protobuf",
+            {
+                "prefix": "application",
+                "mime": "vnd.google.protobuf",
+                "ext": None,
+                "pairs": None,
+            },
+        ),
+        (
+            "application/vnd.myapp.type+xml",
+            {
+                "prefix": "application",
+                "mime": "vnd.myapp.type",
+                "ext": "xml",
+                "pairs": None,
+            },
+        ),
+        (
+            "application/x-protobuf",
+            {"prefix": "application", "mime": "x-protobuf", "ext": None, "pairs": None},
+        ),
+        ("text/plain", {"prefix": "text", "mime": "plain", "ext": None, "pairs": None}),
+        (
+            "text/html; charset=utf8",
+            {"prefix": "text", "mime": "html", "pairs": "; charset=utf8", "ext": None},
+        ),
+        (
+            "text/tsv+csv",
+            {"prefix": "text", "mime": "tsv", "ext": "csv", "pairs": None},
+        ),
+        (
+            "text/tsv+csv; charset=utf8",
+            {"prefix": "text", "mime": "tsv", "ext": "csv", "pairs": "; charset=utf8"},
+        ),
+        (
+            "user/format-0",
+            {"prefix": "user", "mime": "format-0", "ext": None, "pairs": None},
+        ),
+        (
+            "user/format-853",
+            {"prefix": "user", "mime": "format-853", "ext": None, "pairs": None},
+        ),
+    ],
+)
+def test_parse_str(mimetype, expected):
+    """
+    Test parsing a mimetype into its components.
+    """
+
+    assert mt._parse_str(mimetype) == expected


### PR DESCRIPTION
<!--
# Welcome Contributor!

Thank you for contributing to PyEnsign, please follow the instructions below to get
your PR started off on the right foot.

## First Steps

1. Are you merging from a feature branch into develop?

    _If not, please create a feature branch and change your PR to merge from that branch
    into the PyEnsign `develop` branch._

2. Does your PR have a title?

    _Please ensure your PR has a short, informative title, e.g. "Enables user to publish to multiple topics at once" or "Corrects bug in Subscriber that causes index error"_

3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
-->

This PR fixes #19  which requested a feature to allow the user to specify IETF mimetypes instead of having to use the protocol buffer enums.

I have made the following changes:

1. Added a mimetypes source file with a list of developer constants for specifying mimetypes.
2. Added a method to parse mimetypes from str or int.
3. Added mimetype tests and modified the Event helper class to be compatible with the changes.

Questions for the @rotationalio/maintainers:

- [ ] Should we have a default mimetype instead of erroring in the Event helper?

### CHECKLIST

<!--
Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
-->

- [x] _Is the commit message formatted correctly?_

<!-- If you've changed any code -->

- [x] _Do all of your functions and methods have docstrings?_
- [x] _Have you added/updated unit tests where appropriate?_
- [x] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_

