### PR TITLE
Update to git flow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
       - "v*"
     tags:
       - "v*"
@@ -40,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: rotationalio/ensign
-          ref: main
+          ref: develop
           path: ${{ github.workspace }}/ensign
 
       - name: Build protocol buffers


### PR DESCRIPTION
This updates the test workflow to use the Ensign develop branch for building the protocol buffers and also run the tests when pushing to develop.