### PR TITLE
ServerStatus data structure

### DIFF
--- a/pyensign/ensign.py
+++ b/pyensign/ensign.py
@@ -4,6 +4,7 @@ import json
 from ulid import ULID
 
 from pyensign.connection import Client
+from pyensign.status import ServerStatus
 from pyensign.utils.topics import Topic, TopicCache
 from pyensign.connection import Connection
 from pyensign.api.v1beta1 import topic_pb2
@@ -446,12 +447,12 @@ class Ensign:
 
         Returns
         -------
-        str
+        ServerStatus:
             Status of the server.
         """
 
         status, version, uptime, _, _ = await self.client.status()
-        return "status: {}\nversion: {}\nuptime: {}".format(status, version, uptime)
+        return ServerStatus(status, version, uptime)
 
     def _resolve_topic(self, topic):
         """

--- a/pyensign/status.py
+++ b/pyensign/status.py
@@ -1,0 +1,13 @@
+
+class ServerStatus(object):
+
+    def __init__(self, status, version, uptime):
+        # TODO: convert status enum integer into string
+        # TODO: convert uptime into a timedelta
+        # TODO: handle the other fields returned from client.status
+        self.status = status
+        self.version = version
+        self.uptime = uptime
+
+    def __str__(self):
+        return f"status: {self.status}\nversion: {self.version}\nuptime: {self.uptime}"

--- a/pyensign/status.py
+++ b/pyensign/status.py
@@ -1,6 +1,4 @@
-
 class ServerStatus(object):
-
     def __init__(self, status, version, uptime):
         # TODO: convert status enum integer into string
         # TODO: convert uptime into a timedelta


### PR DESCRIPTION
This PR converts the `client.status()` method to return a data structure with parsed values rather than a string, but will (hopefully) still pass tests since the class is stringified the same way.

I have made the following changes:

1. Modified the `Ensign.status` method to return a class instead of a string
2. Created a `ServerStatus` class to represent the grpc return value
3. Ensured the `ServerStatus.__str__` method is the same as the original string returned from `Ensign.status`

### TODOs and questions

Still to do:

- [ ] convert status enum integer into string
- [ ] convert uptime into a timedelta
- [ ] handle the other fields returned from client.status
- [ ] document the server status struct

Questions for the @rotationalio/maintainers:

- [ ] what documentation format are we using for docstrings?
- [ ] should we get a sphinx doc for the API documentation up on read the docs?

### CHECKLIST

<!--
Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
-->

- [x] _Is the commit message formatted correctly?_

<!-- If you've changed any code -->

- [ ] _Do all of your functions and methods have docstrings?_
- [ ] _Have you added/updated unit tests where appropriate?_
- [ ] _Have you run the unit tests using `pytest`?_
- [ ] _Is your code style correct (are you using PEP8, pyflakes)?_

