### PR TITLE
Fix publish hang

### DIFF
--- a/pyensign/iterator.py
+++ b/pyensign/iterator.py
@@ -48,9 +48,6 @@ class ResponseIterator:
                 rep = await self.stream.read()
             except grpc.aio.AioRpcError:
                 break
-            except asyncio.CancelledError:
-                # If the channel is closed, gRPC cancels the task
-                break
             # Handle unexpected end of stream
             if rep is grpc.aio.EOF:
                 break

--- a/pyensign/utils/tasks.py
+++ b/pyensign/utils/tasks.py
@@ -28,7 +28,9 @@ class WorkerPool:
                 await coro
                 if done_callback:
                     done_callback()
-            except asyncio.QueueEmpty:
+            except (asyncio.QueueEmpty, asyncio.CancelledError):
+                # If there is nothing to be done or someone cancelled us, stop the
+                # worker
                 break
         self.workers.remove(asyncio.current_task())
 

--- a/tests/pyensign/test_connection.py
+++ b/tests/pyensign/test_connection.py
@@ -57,7 +57,8 @@ def grpc_servicer():
 def client(grpc_addr, grpc_server, auth):
     """
     This defines a client fixture that connects to the mock gRPC service which is
-    listening on grpc_addr.
+    listening on grpc_addr, with reconnect timeouts which are intentionally very short
+    to test reconnect logic.
     TODO: We currently have to include grpc_server here to force pytest to load the
     server fixture which is defined in the pytest-grpc library and start the server,
     need to figure out a better way of handling that.
@@ -71,7 +72,24 @@ def client(grpc_addr, grpc_server, auth):
 
 
 @pytest.fixture()
+def client_reconnect_timeout(grpc_addr, grpc_server, auth):
+    """
+    This defines a client fixture that connects to the mock gRPC service but uses the
+    default reconnect timeout, which should be long enough to cause reconnect timeouts
+    in tests.
+    """
+    return Client(
+        Connection(grpc_addr, insecure=True, auth=auth),
+        topic_cache=Cache(),
+    )
+
+
+@pytest.fixture()
 def client_no_reconnect(grpc_addr, grpc_server, auth):
+    """
+    This defines a client fixture that connects to the mock gRPC service but uses no
+    reconnect timeout to test timeout logic.
+    """
     return Client(
         Connection(grpc_addr, insecure=True, auth=auth),
         topic_cache=Cache(),
@@ -434,6 +452,21 @@ class TestClient:
             while not published:
                 await asyncio.sleep(0.1)
             await client.close()
+
+        asyncio.run(publish())
+
+    def test_publish_cancelled(self, client_reconnect_timeout):
+        """
+        Test that async publish tasks exit gracefully when cancelled. On fail this test
+        will hang. In the real world, we don't want code with PyEnsign in it to hang if
+        the user code has already returned.
+        """
+
+        async def publish():
+            await client_reconnect_timeout.publish(
+                OTTERS_TOPIC,
+                async_iter([Event(data=b"event", mimetype="text/plain")]),
+            )
 
         asyncio.run(publish())
 

--- a/tests/pyensign/test_iterator.py
+++ b/tests/pyensign/test_iterator.py
@@ -67,7 +67,6 @@ class TestResponseIterator:
         "exception",
         [
             (grpc.aio.AioRpcError(None, None, None)),
-            (asyncio.CancelledError()),
         ],
     )
     async def test_iter_exception(self, exception):


### PR DESCRIPTION
<!--
# Welcome Contributor!

Thank you for contributing to PyEnsign, please follow the instructions below to get
your PR started off on the right foot.

## First Steps

1. Are you merging from a feature branch into develop?

    _If not, please create a feature branch and change your PR to merge from that branch
    into the PyEnsign `develop` branch._

2. Does your PR have a title?

    _Please ensure your PR has a short, informative title, e.g. "Enables user to publish to multiple topics at once" or "Corrects bug in Subscriber that causes index error"_

3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
-->

This PR fixes an issue with the one-off publish scenario hanging the program. The issue is that we need to be treating the `asyncio.CancelledError` exception more seriously, if the user wants to cancel the task (e.g. closing the event loop) then we should honor that.

I have made the following changes:

1. Moved task exception handling up to the worker level.
2. Added regression test to catch the hang scenario

### TODOs and questions

<!--
If this is a work-in-progress (WIP), list the changes you still need to make and/or questions or the PyEnsign team. You can also mention extensions to your work that might be added as an issue to work on after the PR.
-->

### CHECKLIST

<!--
Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
-->

- [x] _Is the commit message formatted correctly?_

<!-- If you've changed any code -->

- [x] _Do all of your functions and methods have docstrings?_
- [x] _Have you added/updated unit tests where appropriate?_
- [x] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_

