### PR TITLE
Catch exceptions in ack handlers

### DIFF
--- a/tests/pyensign/test_connection.py
+++ b/tests/pyensign/test_connection.py
@@ -26,6 +26,7 @@ from pyensign.exceptions import (
     AuthenticationError,
     EnsignRPCError,
     QueryNoRows,
+    NackError,
 )
 
 
@@ -233,15 +234,19 @@ class MockServicer(ensign_pb2_grpc.EnsignServicer):
         )
         yield ensign_pb2.PublisherReply(ready=stream_ready)
 
-        for _ in range(3):
+        for i in range(3):
             # Ensure the client is only sending events
             req = next(request_iterator)
             assert isinstance(req, ensign_pb2.PublisherRequest)
             assert req.WhichOneof("embed") == "event"
 
-            # Send back an ack to the client
-            ack = ensign_pb2.Ack(id=req.event.local_id)
-            yield ensign_pb2.PublisherReply(ack=ack)
+            # Alternate acks/nacks to the client for full testability
+            if i % 2 == 0:
+                ack = ensign_pb2.Ack(id=req.event.local_id)
+                yield ensign_pb2.PublisherReply(ack=ack)
+            else:
+                nack = ensign_pb2.Nack(id=req.event.local_id)
+                yield ensign_pb2.PublisherReply(nack=nack)
 
         yield ensign_pb2.PublisherReply(close_stream=ensign_pb2.CloseStream())
 
@@ -377,33 +382,43 @@ class TestClient:
             Event(data=b"event 2", mimetype="text/plain"),
         ]
         ack_ids = []
-        published = asyncio.Event()
+        nack_ids = []
 
         async def source_events(events):
             for event in events:
                 yield event
 
-        async def record_acks(ack):
+        async def on_ack(ack):
             nonlocal ack_ids
             ack_ids.append(ack.id)
-            if len(ack_ids) >= 3:
-                published.set()
 
-        await client.publish(topic, source_events(events), on_ack=record_acks)
+        async def on_nack(nack):
+            nonlocal nack_ids
+            nack_ids.append(nack.id)
+
+        await client.publish(
+            topic, source_events(events), on_ack=on_ack, on_nack=on_nack
+        )
 
         # Should be able to resume publishing to an existing stream.
         more_events = [
             Event(data=b"event 3", mimetype="text/plain"),
         ]
-        await client.publish(topic, source_events(more_events), on_ack=record_acks)
-        await published.wait()
+        await client.publish(
+            topic, source_events(more_events), on_ack=on_ack, on_nack=on_nack
+        )
+
+        # Wait for all the events to be acked or nacked.
+        await events[0].wait_for_ack()
+        assert events[0].acked()
+        with pytest.raises(NackError):
+            await events[1].wait_for_ack()
+        assert events[1].nacked()
+        await more_events[0].wait_for_ack()
+        assert more_events[0].acked()
 
         await client.close()
-        assert len(ack_ids) == len(events) + len(more_events)
-        for event in events:
-            assert event.acked()
-        for event in more_events:
-            assert event.acked()
+        assert len(ack_ids) + len(nack_ids) == len(events) + len(more_events)
 
         # Topic IDs from the server should be saved in the client.
         id = client.topics.get(OTTERS_TOPIC.name)
@@ -451,6 +466,35 @@ class TestClient:
         with pytest.raises(UnknownTopicError):
             await client.publish(topic, [])
         await client.close()
+
+    @pytest.mark.asyncio
+    async def test_publish_ack_error(self, caplog, client):
+        """
+        Test when an exception is raised inside an ack handler it is caught and logged.
+        """
+
+        async def on_ack(ack):
+            raise Exception("I could not process this ack", ack)
+
+        async def on_nack(nack):
+            raise Exception("I could not process this nack", nack)
+
+        acked_event = Event(data=b"event", mimetype="text/plain")
+        nacked_event = Event(data=b"event", mimetype="text/plain")
+
+        async def source_events():
+            yield acked_event
+            yield nacked_event
+
+        await client.publish(
+            OTTERS_TOPIC, source_events(), on_ack=on_ack, on_nack=on_nack
+        )
+        await acked_event.wait_for_ack()
+        with pytest.raises(NackError):
+            await nacked_event.wait_for_ack()
+        await client.close()
+        assert "I could not process this ack" in caplog.text
+        assert "I could not process this nack" in caplog.text
 
     def test_publish_sync(self, client):
         """
@@ -573,17 +617,22 @@ class TestClient:
             Event(data=b"event 3", mimetype="text/plain"),
         ]
         ack_ids = []
+        nack_ids = []
         event_ids = []
 
-        async def record_acks(ack):
+        async def on_ack(ack):
             nonlocal ack_ids
             ack_ids.append(ack.id)
+
+        async def on_nack(nack):
+            nonlocal nack_ids
+            nack_ids.append(nack.id)
 
         async def source_events():
             for event in events:
                 yield event
 
-        await client.publish(topic, source_events(), on_ack=record_acks)
+        await client.publish(topic, source_events(), on_ack=on_ack, on_nack=on_nack)
 
         # Consume all the events
         async for event in client.subscribe(iter(["expresso", "arabica"])):
@@ -595,10 +644,11 @@ class TestClient:
                 break
 
         await client.close()
-        assert len(ack_ids) == len(events)
+        assert len(ack_ids) + len(nack_ids) == len(events)
         assert len(event_ids) == len(events)
-        for event in events:
-            assert event.acked()
+        assert events[0].acked()
+        assert events[1].nacked()
+        assert events[2].acked()
 
     @pytest.mark.asyncio
     async def test_en_sql(self, client):


### PR DESCRIPTION
<!--
# Welcome Contributor!

Thank you for contributing to PyEnsign, please follow the instructions below to get
your PR started off on the right foot.

## First Steps

1. Are you merging from a feature branch into develop?

    _If not, please create a feature branch and change your PR to merge from that branch
    into the PyEnsign `develop` branch._

2. Does your PR have a title?

    _Please ensure your PR has a short, informative title, e.g. "Enables user to publish to multiple topics at once" or "Corrects bug in Subscriber that causes index error"_

3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
-->

This PR fixes an issue with users not seeing things getting acks getting printed from ack handlers. The problem is that we are not catching exceptions thrown by ack handlers. Even though these exceptions are thrown (and uncaught) from user code, we don't want the PyEnsign task workers to die because of this.

I have made the following changes:

1. Add exception handling for the ack handlers
2. Log any uncaught exceptions so the user has more information to debug

### TODOs and questions

<!--
If this is a work-in-progress (WIP), list the changes you still need to make and/or questions or the PyEnsign team. You can also mention extensions to your work that might be added as an issue to work on after the PR.
-->

### CHECKLIST

<!--
Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
-->

- [x] _Is the commit message formatted correctly?_

<!-- If you've changed any code -->

- [x] _Do all of your functions and methods have docstrings?_
- [x] _Have you added/updated unit tests where appropriate?_
- [x] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_

